### PR TITLE
Drools6 fixes

### DIFF
--- a/drooms-game-impl/src/main/java/org/drooms/impl/logic/DecisionMaker.java
+++ b/drooms-game-impl/src/main/java/org/drooms/impl/logic/DecisionMaker.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.codehaus.plexus.classworlds.strategy.Strategy;
 import org.drools.core.time.SessionPseudoClock;
 import org.drooms.api.Move;
 import org.drooms.api.Node;
@@ -38,7 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Represents a {@link Player}'s {@link Strategy} in action. This class holds
+ * Represents a {@link Player}'s Strategy in action. This class holds
  * and maintains Drools engine's state for each particular player.
  * 
  * <p>

--- a/drooms-game-impl/src/main/java/org/drooms/impl/util/GameProperties.java
+++ b/drooms-game-impl/src/main/java/org/drooms/impl/util/GameProperties.java
@@ -8,7 +8,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Properties;
 
-import org.codehaus.plexus.classworlds.strategy.Strategy;
 import org.drooms.api.Player;
 import org.drooms.util.CommonProperties;
 
@@ -39,7 +38,7 @@ import org.drooms.util.CommonProperties;
  * <dt>worm.max.inactive.turns (defaults to 3)</dt>
  * <dd>Maximum number of turns of inactivity after which a player may be terminated, if the game decides so.</dd>
  * <dt>worm.timeout.seconds (defaults to 1)</dt>
- * <dd>The maximum amount of time that the {@link Player}'s {@link Strategy} has to make a decision on the next movement
+ * <dd>The maximum amount of time that the {@link Player}'s Strategy has to make a decision on the next movement
  * of the worm. If it doesn't make it in time, STAY is enforced, potentially leading to the worm being terminated for
  * inactivity.</dd>
  * <dt>worm.survival.bonus (defaults to 5)</dt>

--- a/drooms-game-impl/src/main/java/org/drooms/impl/util/PlayerAssembly.java
+++ b/drooms-game-impl/src/main/java/org/drooms/impl/util/PlayerAssembly.java
@@ -8,14 +8,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
-import org.codehaus.plexus.classworlds.strategy.Strategy;
 import org.drooms.api.Player;
 import org.drooms.impl.GameController;
 import org.kie.api.KieServices;
 import org.kie.api.builder.ReleaseId;
 
 /**
- * A helper class to load {@link Strategy} implementations for all requested {@link Player}s.
+ * A helper class to load Strategy implementations for all requested {@link Player}s.
  */
 public class PlayerAssembly {
 


### PR DESCRIPTION
Found a few Errors in Drooms related to migration to Drools 6:

The plexus reference gave some weird problems during compilation.
The clock type caused a runtime problem (ClassCastException).
